### PR TITLE
Implement automatic chunking on export

### DIFF
--- a/source/isodi.tools/objects.d
+++ b/source/isodi.tools/objects.d
@@ -7,9 +7,6 @@ import std.conv;
 import std.path;
 import std.array;
 import std.format;
-import fs = std.file;
-
-import isodi.tilemap;
 
 import isodi.tools.themes;
 import isodi.tools.project;
@@ -104,7 +101,7 @@ struct Objects {
 
                 import isodi.tools.save_project;
 
-                const path = project.filename.setExtension("isdproj");
+                const path = project.filename.setExtension("isotools");
 
                 // Save the project
                 project.saveProject(path);
@@ -127,18 +124,10 @@ struct Objects {
 
                 if (!requireFilename) return;
 
-                const path = project.filename.setExtension("isodi");
+                import isodi.tools.save_tilemap;
 
-                // Write to a buffer
-                auto appn = appender!(ubyte[]);
-                project.display.saveTilemap(appn);
+                project.exportTilemaps();
 
-                // Save the data
-                fs.write(path, appn[]);
-
-                // Add a status text
-                project.status.text = format!"Exported to %s"(path);
-                project.status.updateSize();
 
             },
 

--- a/source/isodi.tools/open_file.d
+++ b/source/isodi.tools/open_file.d
@@ -82,7 +82,7 @@ void forwardFile(ref Tabs tabs, string path) {
     }
 
     // Case 4: project file
-    else if (path.isFile && path.extension == ".isdproj") {
+    else if (path.isFile && path.extension == ".isotools") {
 
         // Load the project
         tabs.addProject(loadProject(path));

--- a/source/isodi.tools/options.d
+++ b/source/isodi.tools/options.d
@@ -15,51 +15,72 @@ struct ProjectOptions {
 
 }
 
-/// Get UI for the project's options
-GluiFrame projectOptionsUI(Project project) {
+class ProjectOptionsFrame : GluiFrame {
 
-    auto options = &project.options;
-
-    GluiFrame ret;
+    Project project;
     GluiTextInput chunkSizeInput;
 
-    ret = vframe(
+    alias hidden = GluiFrame.hidden;
 
-        theme,
-        layout!(1, "center"),
+    @property
+    override bool hidden(bool value) {
 
-        label(
-            layout!"center",
-            "Project options",
-        ),
+        // Update values before showing again
+        if (value == false) updateValues();
 
-        vframe(
+        return super.hidden = value;
+
+    }
+
+    this(Project project) {
+
+        this.project = project;
+
+        // Create the node
+        super(
+
+            .theme,
+            .layout!(1, "center"),
+
             label(
-                "Enable automatic chunking"
+                .layout!"center",
+                "Project options",
             ),
-            label(
-                "Chunks will always be square. To enable chunking, specify square length in the field below. "
-                ~ "Chunks will automatically be exported to separate files on tilemap export. Set to 0 to disable."
+
+            vframe(
+                label(
+                    "Enable automatic chunking"
+                ),
+                label(
+                    "Chunks will always be square. To enable chunking, specify square length in the field below. "
+                    ~ "Chunks will automatically be exported to separate files on tilemap export. Set to 0 to disable."
+                ),
+                chunkSizeInput = textInput(
+                    .layout!"fill",
+                    "Chunk size",
+                    () {
+                        project.options.chunkSize = chunkSizeInput.value.to!int.ifThrown(0);
+                    }
+                ),
             ),
-            chunkSizeInput = textInput(
-                layout!"fill",
-                "Chunk size",
-                () {
-                    project.options.chunkSize = chunkSizeInput.value.to!int.ifThrown(0);
-                }
+
+            button(
+                .layout!(1, "center"),
+                "Close",
+                { hide(); },
             ),
-        ),
 
-        button(
-            layout!(1, "center"),
-            "Close",
-            { ret.hide(); },
-        ),
+        );
+        hide();
 
-    );
+    }
 
-    ret.hide();
+    void updateValues() {
 
-    return ret;
+        auto options = &project.options;
+
+        chunkSizeInput.value = options.chunkSize.to!string;
+
+    }
 
 }

--- a/source/isodi.tools/project.d
+++ b/source/isodi.tools/project.d
@@ -245,7 +245,7 @@ class Project {
         scope (exit) rlPopMatrix();
 
         const size = cast(int) options.chunkSize;
-        const name = filename.baseName(".isdproj");
+        const name = filename.baseName(".isotools");
         const cellSize = display.cellSize;
         const distance = to!int(250 / size);
 

--- a/source/isodi.tools/project.d
+++ b/source/isodi.tools/project.d
@@ -3,7 +3,10 @@ module isodi.tools.project;
 import glui;
 import raylib;
 
+import std.conv;
 import std.math;
+import std.path;
+import std.string;
 import std.traits;
 
 import isodi;
@@ -79,19 +82,11 @@ class Project {
 
         display = new RaylibDisplay;
         display.camera.offset = Camera.Offset(0, 0, 0);
-        display.camera.follow = display.addAnchor({
+        display.camera.follow = display.addAnchor({ });
 
-            rlPushMatrix();
-            scope (exit) rlPopMatrix();
-
-            // Move to camera
-            const campos = display.snapWorldPosition(display.raylibCamera.position);
-            rlTranslatef(campos.x, brushHeight * display.cellSize, campos.z);
-
-            // Draw the grid
-            //DrawGrid(10, display.cellSize);
-
-        });
+        // Add an anchor for drawing the overlay
+        auto overlayAnchor = display.addAnchor(&drawOverlay);
+        overlayAnchor.drawOrder = RaylibAnchor.DrawOrder.last;
 
         _brushAnchor = cast(RaylibAnchor) display.addAnchor({ });
 
@@ -99,7 +94,7 @@ class Project {
         objects = Objects(this);
         status = label();
 
-        optionsFrame = projectOptionsUI(this);
+        optionsFrame = new ProjectOptionsFrame(this);
 
     }
 
@@ -238,6 +233,49 @@ class Project {
         auto position = display.isodiPosition(mouseHit.position);
         position.height.depth = 0;
         return position;
+
+    }
+
+    void drawOverlay() {
+
+        // If chunking enabled
+        if (!options.chunkSize) return;
+
+        rlPushMatrix();
+        scope (exit) rlPopMatrix();
+
+        const size = cast(int) options.chunkSize;
+        const name = filename.baseName(".isdproj");
+        const cellSize = display.cellSize;
+        const distance = to!int(250 / size);
+
+        // Get current chunk relative to camera
+        auto chunkOffset = display.camera.offset;
+        chunkOffset.x = to!int(chunkOffset.x / size);
+        chunkOffset.y = to!int(chunkOffset.y / size);
+
+        // Get tile position for the chunk
+        auto offset = chunkOffset;
+        offset.x *= size;
+        offset.y *= size;
+
+        // Place a grid
+        rlTranslatef(offset.x * cellSize, brushHeight * cellSize, offset.y * cellSize);
+        DrawGrid(distance, options.chunkSize * display.cellSize);
+
+        // Caption each chunk
+        foreach (i; -distance/2 .. distance/2)
+        foreach (j; -distance/2 .. distance/2) {
+
+            rlPushMatrix();
+            scope (exit) rlPopMatrix();
+
+            const caption = format!"%s_%s_%s.isodi"(name, chunkOffset.x + i, chunkOffset.y + j);
+            rlTranslatef(i * cellSize * size, 0, j * cellSize * size);
+            rlRotatef(90, 1, 0, 0);
+            DrawText(caption.toStringz, 0, 0, 48, Colors.WHITE);
+
+        }
 
     }
 

--- a/source/isodi.tools/save_project.d
+++ b/source/isodi.tools/save_project.d
@@ -68,7 +68,8 @@ ubyte[] saveProject(Project project) {
     // Save pack list
     // TODO: save pack name and have a program-global registry of packs
     // Would allow downloading assets like in the main client and easily transfering projects between different devices
-    bin.get(project.display.packs.map!"a.path".array);
+    const packs = project.display.packs[].map!"a.path".array;
+    bin.get(packs);
 
     // Save the project as a huge tilemap
     // Note: chunking does not apply here, but on export
@@ -124,6 +125,8 @@ Project loadProject(ubyte[] data) {
 
     // Get the options
     bin.get(project.options);
+
+    // TODO: if failed to load a tile or pack, make a prompt to add more packs
 
     // Load packs
     auto packs = bin.read!(string[]);

--- a/source/isodi.tools/save_tilemap.d
+++ b/source/isodi.tools/save_tilemap.d
@@ -1,0 +1,15 @@
+module isodi.tools.save_tilemap;
+
+import isodi.tilemap;
+
+import isodi.tools.project;
+
+void exportTilemaps(ref Project project) {
+
+    if (project.options.chunkSize) {
+
+        // TODO
+
+    }
+
+}

--- a/source/isodi.tools/save_tilemap.d
+++ b/source/isodi.tools/save_tilemap.d
@@ -1,15 +1,81 @@
 module isodi.tools.save_tilemap;
 
+import std.file;
+import std.path;
+import std.math;
+import std.array;
+import std.format;
+
+import isodi.cell;
 import isodi.tilemap;
 
 import isodi.tools.project;
 
+private struct ChunkPosition {
+
+    int x, y;
+
+}
+
 void exportTilemaps(ref Project project) {
 
-    if (project.options.chunkSize) {
+    // Chunking
+    if (int chunkSize = project.options.chunkSize) {
 
-        // TODO
+        Cell[][ChunkPosition] chunks;
+
+        // Put cells into chunks
+        foreach (cell; project.display.cells) {
+
+            auto position = ChunkPosition(
+                cast(int) floor(1.0 * cell.position.x / chunkSize),
+                cast(int) floor(1.0 * cell.position.y / chunkSize),
+            );
+
+            chunks.require(position) ~= cell;
+
+        }
+
+        const basePath = project.filename.stripExtension;
+
+        // Check each chunk
+        foreach (key, chunk; chunks) {
+
+            const path = format!"%s_%s_%s.isodi"(basePath, key.x, key.y);
+            exportTilemap(chunk, path);
+
+        }
+
+        // Set status text
+        project.status.text = format!"Exported %s chunks to %s/"(chunks.length, basePath.dirName);
+        project.status.updateSize();
 
     }
+
+    // No chunking, export as a single tilemap
+    else {
+
+        const path = project.filename.setExtension("isodi");
+
+        // Export the tilemap
+        exportTilemap(project.display.cells.array, path);
+
+        // Add a status text
+        project.status.text = format!"Exported to %s"(path);
+        project.status.updateSize();
+
+    }
+
+}
+
+/// Export a tilemap to the given file.
+private void exportTilemap(Cell[] cells, string path) {
+
+    // Write to a buffer
+    auto appn = appender!(ubyte[]);
+    saveTilemap(cells, appn);
+
+    // Save the data
+    write(path, appn[]);
 
 }

--- a/source/isodi.tools/tabs.d
+++ b/source/isodi.tools/tabs.d
@@ -82,7 +82,7 @@ struct Tabs {
         *frames.objects = project.objects.rootFrame;
         *frames.status  = project.status;
         *frames.options = project.optionsFrame;
-        frames.palette.updateSize();
+        frames.palette.updateSize(); // TODO this won't work, the elements may have not been drawn yet
 
         // Set the project
         openProject = project;


### PR DESCRIPTION
Isodi could get support for chunk metadata, so we could place information about neighboring chunks within their files. This might not be necessary though, as the filename itself provides this data too.